### PR TITLE
Updated code for API 72.1

### DIFF
--- a/flipper_hero.c
+++ b/flipper_hero.c
@@ -46,8 +46,9 @@ void end_game(PluginState* plugin_state) {
     plugin_state->isGameOver = true;
 }
 
-static void input_callback(InputEvent* input_event, FuriMessageQueue* event_queue) {
-    furi_assert(event_queue);
+static void input_callback(InputEvent* input_event, void* ctx) {
+
+    FuriMessageQueue* event_queue = ctx;
     PluginEvent event = {.type = EventTypeKey, .input = *input_event};
     furi_message_queue_put(event_queue, &event, FuriWaitForever);
 }


### PR DESCRIPTION
Modified the `input_callback` function to conform with API 72.1.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the `input_callback` function to conform with API 72.1 by changing the parameter type for the event queue to a context pointer.

Enhancements:
- Modify the `input_callback` function to use a context pointer for the event queue, aligning with API 72.1 requirements.

<!-- Generated by sourcery-ai[bot]: end summary -->