### PR TITLE
Fix flipper hero build system

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+env = DefaultEnvironment()
+
+# Build the application when no target is specified
+Default(".")

--- a/SetupEnv.md
+++ b/SetupEnv.md
@@ -28,6 +28,12 @@ Set `ufbt` for the unleashed firmware, specifying the custom repository URL:
 > ufbt update --index-url=https://up.unleashedflip.com/directory.json
 ```
 
+**Momentum Firmware:**
+Configure `ufbt` to use the Momentum firmware index:
+```bash
+> ufbt update --index-url=https://up.momentum-fw.dev/firmware/directory.json
+```
+
 ### Build Your App
 Build your application:
 ```bash

--- a/application.fam
+++ b/application.fam
@@ -12,6 +12,7 @@ App(
     fap_version="1.3",
     fap_commit="1602e6c14b8ced22ebe3f82dbe1fab5317071b30",
     fap_icon="icons/hex_10px.png",
+    fap_icon_assets="icons",
     fap_category="Games",
     fap_author="Mentoster",
     fap_description="Arrow Speed Game",

--- a/flipper_hero.c
+++ b/flipper_hero.c
@@ -4,6 +4,7 @@
 #include "data/data.h"
 #include "view/arrows.h"
 #include "helpers/storage.h"
+#include "flipper_hero_icons.h"
 
 #define MIN_ARROWS 3
 #define MAX_ARROWS 8


### PR DESCRIPTION
## Summary
- simplify `SConstruct` so default target builds the app
- document building for Momentum firmware in SetupEnv guide

## Testing
- `scons --version`
- `scons` *(no targets built due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_687a6c199338832c8e0772c71774dae4